### PR TITLE
Add a shortcut integration [sc-25996]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+gpt-updater:description

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Replace `<GITHUB_TOKEN>`, `<OPENAI_TOKEN>`, `<OWNER>`, `<REPO>`, and `<PR_NUMBER
 The usage for the `description` command is similar to the `review` command. Replace `review` with `description` in the command above and execute.
 The only difference is that the `description` command has extra options, `--jira-url` and `--shortcut-url`, which are used to generate Jira or Shortcut links in the description, accordingly.
 
+#### Placeholders
+
+You can use the following placeholders in the description template:
+- `gpt-updater:description` - when this placeholder is present in your pull request description, it will be replaced with the generated description; otherwise, the entire description field will be replaced.
+
 ## GitHub Action
 
 This script can be used as a GitHub Action, allowing it to run automatically in your repository. To get started, add a new workflow file in your repository, such as: `.github/workflows/gpt_pullrequest_updater.yml`.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Replace `<GITHUB_TOKEN>`, `<OPENAI_TOKEN>`, `<OWNER>`, `<REPO>`, and `<PR_NUMBER
 ### Description Command
 
 The usage for the `description` command is similar to the `review` command. Replace `review` with `description` in the command above and execute.
-Only difference is that `description` command has extra option `--jira-url` which is used to generate Jira links in the description.
+The only difference is that the `description` command has extra options, `--jira-url` and `--shortcut-url`, which are used to generate Jira or Shortcut links in the description, accordingly.
 
 ## GitHub Action
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ Replace `<GITHUB_TOKEN>`, `<OPENAI_TOKEN>`, `<OWNER>`, `<REPO>`, and `<PR_NUMBER
 The usage for the `description` command is similar to the `review` command. Replace `review` with `description` in the command above and execute.
 The only difference is that the `description` command has extra options, `--jira-url` and `--shortcut-url`, which are used to generate Jira or Shortcut links in the description, accordingly.
 
-#### Placeholders
+### Templates
 
-You can use the following placeholders in the description template:
+You can add the file `.github/pull_request_template.md` to your repository to customize the default pull request description. The template file can contain the following placeholders: 
+
 - `gpt-updater:description` - when this placeholder is present in your pull request description, it will be replaced with the generated description; otherwise, the entire description field will be replaced.
 
 ## GitHub Action

--- a/cmd/description/main.go
+++ b/cmd/description/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/ravilushqa/gpt-pullrequest-updater/shortcut"
 	"os"
 	"os/signal"
 	"syscall"
@@ -15,6 +14,7 @@ import (
 	ghClient "github.com/ravilushqa/gpt-pullrequest-updater/github"
 	"github.com/ravilushqa/gpt-pullrequest-updater/jira"
 	oAIClient "github.com/ravilushqa/gpt-pullrequest-updater/openai"
+	"github.com/ravilushqa/gpt-pullrequest-updater/shortcut"
 )
 
 var opts struct {
@@ -26,7 +26,7 @@ var opts struct {
 	OpenAIModel     string `long:"openai-model" env:"OPENAI_MODEL" description:"OpenAI model" default:"gpt-3.5-turbo"`
 	Test            bool   `long:"test" env:"TEST" description:"Test mode"`
 	JiraURL         string `long:"jira-url" env:"JIRA_URL" description:"Jira URL. Example: https://jira.atlassian.com"`
-	ShortcutBaseURL string `long:"shortcut-url" env:"SHORTCUT_URL" description:"Shortcut URL. Example: https://app.shortcut.com/foo/"`
+	ShortcutBaseURL string `long:"shortcut-url" env:"SHORTCUT_URL" description:"Shortcut URL. Example: https://app.shortcut.com/foo"`
 }
 
 func main() {
@@ -110,5 +110,5 @@ func buildShortcutContent(shortcutBaseURL string, pr *github.PullRequest) string
 		return ""
 	}
 
-	return fmt.Sprintf("### Shortcut story: [%s](%s)", id, shortcut.GenerateShortcutStoryUrl(shortcutBaseURL, id))
+	return fmt.Sprintf("### Shortcut story: [%s](%s)", id, shortcut.GenerateShortcutStoryURL(shortcutBaseURL, id))
 }

--- a/cmd/description/main.go
+++ b/cmd/description/main.go
@@ -56,7 +56,7 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("error getting pull request: %w", err)
 	}
 
-	if description.IsDescriptionFinished(*pr.Body) {
+	if pr.Body != nil && description.IsDescriptionFinished(*pr.Body) {
 		fmt.Println("Pull request already has a generated description. Skipping...")
 		return nil
 	}
@@ -91,7 +91,7 @@ func run(ctx context.Context) error {
 
 	// Update the pull request description
 	fmt.Println("Updating pull request")
-	updatedPr := description.BuildUpdatedPullRequest(*pr.Body, descriptionInfo)
+	updatedPr := description.BuildUpdatedPullRequest(pr.Body, descriptionInfo)
 	if _, err = githubClient.UpdatePullRequest(ctx, opts.Owner, opts.Repo, opts.PRNumber, updatedPr); err != nil {
 		return fmt.Errorf("error updating pull request: %w", err)
 	}

--- a/cmd/description/main.go
+++ b/cmd/description/main.go
@@ -17,14 +17,15 @@ import (
 )
 
 var opts struct {
-	GithubToken string `long:"gh-token" env:"GITHUB_TOKEN" description:"GitHub token" required:"true"`
-	OpenAIToken string `long:"openai-token" env:"OPENAI_TOKEN" description:"OpenAI token" required:"true"`
-	Owner       string `long:"owner" env:"OWNER" description:"GitHub owner" required:"true"`
-	Repo        string `long:"repo" env:"REPO" description:"GitHub repo" required:"true"`
-	PRNumber    int    `long:"pr-number" env:"PR_NUMBER" description:"Pull request number" required:"true"`
-	OpenAIModel string `long:"openai-model" env:"OPENAI_MODEL" description:"OpenAI model" default:"gpt-3.5-turbo"`
-	Test        bool   `long:"test" env:"TEST" description:"Test mode"`
-	JiraURL     string `long:"jira-url" env:"JIRA_URL" description:"Jira URL. Example: https://jira.atlassian.com"`
+	GithubToken     string `long:"gh-token" env:"GITHUB_TOKEN" description:"GitHub token" required:"true"`
+	OpenAIToken     string `long:"openai-token" env:"OPENAI_TOKEN" description:"OpenAI token" required:"true"`
+	Owner           string `long:"owner" env:"OWNER" description:"GitHub owner" required:"true"`
+	Repo            string `long:"repo" env:"REPO" description:"GitHub repo" required:"true"`
+	PRNumber        int    `long:"pr-number" env:"PR_NUMBER" description:"Pull request number" required:"true"`
+	OpenAIModel     string `long:"openai-model" env:"OPENAI_MODEL" description:"OpenAI model" default:"gpt-3.5-turbo"`
+	Test            bool   `long:"test" env:"TEST" description:"Test mode"`
+	JiraURL         string `long:"jira-url" env:"JIRA_URL" description:"Jira URL. Example: https://jira.atlassian.com"`
+	ShortcutBaseURL string `long:"shortcut-url" env:"SHORTCUT_URL" description:"Shortcut URL. Example: https://app.shortcut.com/foo/"`
 }
 
 func main() {

--- a/cmd/description/main.go
+++ b/cmd/description/main.go
@@ -3,8 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/ravilushqa/gpt-pullrequest-updater/description"
-	oAIClient "github.com/ravilushqa/gpt-pullrequest-updater/openai"
 	"github.com/ravilushqa/gpt-pullrequest-updater/shortcut"
 	"os"
 	"os/signal"
@@ -13,8 +11,10 @@ import (
 	"github.com/google/go-github/v51/github"
 	"github.com/jessevdk/go-flags"
 
+	"github.com/ravilushqa/gpt-pullrequest-updater/description"
 	ghClient "github.com/ravilushqa/gpt-pullrequest-updater/github"
 	"github.com/ravilushqa/gpt-pullrequest-updater/jira"
+	oAIClient "github.com/ravilushqa/gpt-pullrequest-updater/openai"
 )
 
 var opts struct {
@@ -26,7 +26,7 @@ var opts struct {
 	OpenAIModel     string `long:"openai-model" env:"OPENAI_MODEL" description:"OpenAI model" default:"gpt-3.5-turbo"`
 	Test            bool   `long:"test" env:"TEST" description:"Test mode"`
 	JiraURL         string `long:"jira-url" env:"JIRA_URL" description:"Jira URL. Example: https://jira.atlassian.com"`
-	ShortcutBaseUrl string `long:"shortcut-url" env:"SHORTCUT_URL" description:"Shortcut URL. Example: https://app.shortcut.com/foo/"`
+	ShortcutBaseURL string `long:"shortcut-url" env:"SHORTCUT_URL" description:"Shortcut URL. Example: https://app.shortcut.com/foo/"`
 }
 
 func main() {
@@ -74,8 +74,8 @@ func run(ctx context.Context) error {
 		}
 	}
 
-	if opts.ShortcutBaseUrl != "" {
-		shortcutContent := buildShortcutContent(opts.ShortcutBaseUrl, pr)
+	if opts.ShortcutBaseURL != "" {
+		shortcutContent := buildShortcutContent(opts.ShortcutBaseURL, pr)
 		if shortcutContent != "" {
 			completion = fmt.Sprintf("%s\n\n%s", shortcutContent, completion)
 		}
@@ -95,14 +95,14 @@ func run(ctx context.Context) error {
 	return nil
 }
 
-func buildShortcutContent(shortcutBaseUrl string, pr *github.PullRequest) string {
+func buildShortcutContent(shortcutBaseURL string, pr *github.PullRequest) string {
 	fmt.Println("Adding Shortcut ticket")
 
-	id, err := shortcut.ExtractShortcutStoryId(*pr.Title)
+	id, err := shortcut.ExtractShortcutStoryID(*pr.Title)
 
 	if err != nil {
 		// Extracting from the branch name
-		id, err = shortcut.ExtractShortcutStoryId(*pr.Head.Ref)
+		id, err = shortcut.ExtractShortcutStoryID(*pr.Head.Ref)
 	}
 
 	if err != nil {
@@ -110,5 +110,5 @@ func buildShortcutContent(shortcutBaseUrl string, pr *github.PullRequest) string
 		return ""
 	}
 
-	return fmt.Sprintf("### Shortcut story: [%s](%s)", id, shortcut.GenerateShortcutStoryUrl(shortcutBaseUrl, id))
+	return fmt.Sprintf("### Shortcut story: [%s](%s)", id, shortcut.GenerateShortcutStoryUrl(shortcutBaseURL, id))
 }

--- a/cmd/description/main.go
+++ b/cmd/description/main.go
@@ -86,9 +86,14 @@ func run(ctx context.Context) error {
 
 	// Update the pull request description
 	fmt.Println("Updating pull request")
-	updatedPr := description.BuildUpdatedPullRequest(*pr.Body, descriptionInfo)
-	if _, err = githubClient.UpdatePullRequest(ctx, opts.Owner, opts.Repo, opts.PRNumber, updatedPr); err != nil {
-		return fmt.Errorf("error updating pull request: %w", err)
+
+	if description.IsDescriptionFinished(*pr.Body) {
+		fmt.Println("Pull request already has a generated description. Skipping...")
+	} else {
+		updatedPr := description.BuildUpdatedPullRequest(*pr.Body, descriptionInfo)
+		if _, err = githubClient.UpdatePullRequest(ctx, opts.Owner, opts.Repo, opts.PRNumber, updatedPr); err != nil {
+			return fmt.Errorf("error updating pull request: %w", err)
+		}
 	}
 
 	return nil

--- a/cmd/description/main.go
+++ b/cmd/description/main.go
@@ -56,6 +56,11 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("error getting pull request: %w", err)
 	}
 
+	if description.IsDescriptionFinished(*pr.Body) {
+		fmt.Println("Pull request already has a generated description. Skipping...")
+		return nil
+	}
+
 	diff, err := githubClient.CompareCommits(ctx, opts.Owner, opts.Repo, pr.GetBase().GetSHA(), pr.GetHead().GetSHA())
 	if err != nil {
 		return fmt.Errorf("error getting commits: %w", err)
@@ -86,14 +91,9 @@ func run(ctx context.Context) error {
 
 	// Update the pull request description
 	fmt.Println("Updating pull request")
-
-	if description.IsDescriptionFinished(*pr.Body) {
-		fmt.Println("Pull request already has a generated description. Skipping...")
-	} else {
-		updatedPr := description.BuildUpdatedPullRequest(*pr.Body, descriptionInfo)
-		if _, err = githubClient.UpdatePullRequest(ctx, opts.Owner, opts.Repo, opts.PRNumber, updatedPr); err != nil {
-			return fmt.Errorf("error updating pull request: %w", err)
-		}
+	updatedPr := description.BuildUpdatedPullRequest(*pr.Body, descriptionInfo)
+	if _, err = githubClient.UpdatePullRequest(ctx, opts.Owner, opts.Repo, opts.PRNumber, updatedPr); err != nil {
+		return fmt.Errorf("error updating pull request: %w", err)
 	}
 
 	return nil

--- a/description/description.go
+++ b/description/description.go
@@ -50,7 +50,7 @@ func BuildUpdatedPullRequest(existingDescription string, info Info) *github.Pull
 		desc += info.Completion
 	}
 
-	builtBody := fmt.Sprintf("## 🤖 gpt-updater description\n%s\n%s", placeholderFinished, desc)
+	builtBody := fmt.Sprintf("%s\n## 🤖 gpt-updater description\n%s", placeholderFinished, desc)
 
 	if needToUpdateByPlaceholder(existingDescription) {
 		builtBody = strings.Replace(existingDescription, placeholder, builtBody, 1)

--- a/description/description.go
+++ b/description/description.go
@@ -34,7 +34,7 @@ func GenerateCompletion(ctx context.Context, client *oAIClient.Client, diff *git
 	return completion, err
 }
 
-func BuildUpdatedPullRequest(existingDescription string, info Info) *github.PullRequest {
+func BuildUpdatedPullRequest(existingDescription *string, info Info) *github.PullRequest {
 
 	desc := ""
 
@@ -52,8 +52,8 @@ func BuildUpdatedPullRequest(existingDescription string, info Info) *github.Pull
 
 	builtBody := fmt.Sprintf("%s\n## 🤖 gpt-updater description\n%s", placeholderFinished, desc)
 
-	if needToUpdateByPlaceholder(existingDescription) {
-		builtBody = strings.Replace(existingDescription, placeholder, builtBody, 1)
+	if existingDescription != nil && needToUpdateByPlaceholder(*existingDescription) {
+		builtBody = strings.Replace(*existingDescription, placeholder, builtBody, 1)
 	}
 
 	return &github.PullRequest{Body: github.String(builtBody)}

--- a/description/description.go
+++ b/description/description.go
@@ -10,6 +10,12 @@ import (
 	oAIClient "github.com/ravilushqa/gpt-pullrequest-updater/openai"
 )
 
+const Placeholder = "gpt-updater:description"
+const PlaceholderHidden = `<!--
+gpt-updater:description
+-->
+`
+
 func GenerateCompletion(ctx context.Context, client *oAIClient.Client, diff *github.CommitsComparison, pr *github.PullRequest) (string, error) {
 	sumDiffs := calculateSumDiffs(diff)
 

--- a/shortcut/shortcut.go
+++ b/shortcut/shortcut.go
@@ -7,7 +7,7 @@ import (
 
 const storyUrlFormat = "%s/story/%s"
 
-func ExtractShortcutStoryId(title string) (string, error) {
+func ExtractShortcutStoryID(title string) (string, error) {
 
 	// This regular expression pattern matches a Shortcut story ID (e.g. sc-12345).
 	pattern := `sc-([\d]+)`

--- a/shortcut/shortcut.go
+++ b/shortcut/shortcut.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 )
 
-const storyUrlFormat = "%s/story/%s"
+const storyURLFormat = "%s/story/%s"
 
 func ExtractShortcutStoryID(title string) (string, error) {
 
@@ -24,6 +24,6 @@ func ExtractShortcutStoryID(title string) (string, error) {
 	return matches[1], nil
 }
 
-func GenerateShortcutStoryUrl(shortcutBaseUrl, ticketId string) string {
-	return fmt.Sprintf(storyUrlFormat, shortcutBaseUrl, ticketId)
+func GenerateShortcutStoryURL(shortcutBaseUrl, ticketId string) string {
+	return fmt.Sprintf(storyURLFormat, shortcutBaseUrl, ticketId)
 }

--- a/shortcut/shortcut.go
+++ b/shortcut/shortcut.go
@@ -24,6 +24,6 @@ func ExtractShortcutStoryID(title string) (string, error) {
 	return matches[1], nil
 }
 
-func GenerateShortcutStoryURL(shortcutBaseUrl, ticketId string) string {
-	return fmt.Sprintf(storyURLFormat, shortcutBaseUrl, ticketId)
+func GenerateShortcutStoryURL(shortcutBaseURL, ticketID string) string {
+	return fmt.Sprintf(storyURLFormat, shortcutBaseURL, ticketID)
 }

--- a/shortcut/shortcut.go
+++ b/shortcut/shortcut.go
@@ -1,0 +1,29 @@
+package shortcut
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const storyUrlFormat = "%s/story/%s"
+
+func ExtractShortcutStoryId(title string) (string, error) {
+
+	// This regular expression pattern matches a Shortcut story ID (e.g. sc-12345).
+	pattern := `sc-([\d]+)`
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", fmt.Errorf("error compiling regex: %w", err)
+	}
+
+	matches := re.FindStringSubmatch(title)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("no Shortcut story ID found in the input string")
+	}
+
+	return matches[1], nil
+}
+
+func GenerateShortcutStoryUrl(shortcutBaseUrl, ticketId string) string {
+	return fmt.Sprintf(storyUrlFormat, shortcutBaseUrl, ticketId)
+}

--- a/shortcut/shortcut_test.go
+++ b/shortcut/shortcut_test.go
@@ -1,0 +1,51 @@
+package shortcut
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractShortcutStoryID(t *testing.T) {
+	testCases := []struct {
+		title       string
+		expectedID  string
+		expectedErr bool
+	}{
+		{
+			title:       "This is a sample title with a valid story ID sc-12345",
+			expectedID:  "12345",
+			expectedErr: false,
+		},
+		{
+			title:       "No story ID in this title",
+			expectedID:  "",
+			expectedErr: true,
+		},
+		{
+			title:       "Invalid story ID format sc-abcde",
+			expectedID:  "",
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		id, err := ExtractShortcutStoryID(tc.title)
+
+		if tc.expectedErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedID, id)
+		}
+	}
+}
+
+func TestGenerateShortcutStoryURL(t *testing.T) {
+	baseURL := "https://app.shortcut.com/foo"
+	ticketID := "12345"
+	expectedURL := "https://app.shortcut.com/foo/story/12345"
+
+	url := GenerateShortcutStoryURL(baseURL, ticketID)
+	assert.Equal(t, expectedURL, url)
+}


### PR DESCRIPTION
## Summary
The development work was primarily focused on integrating a new feature that allows users to extract and display Shortcut story IDs from GitHub pull requests or branch names. This was achieved by introducing new functions in the 'shortcut' package, updating the 'opts' struct, and updating the documentation.

## Changes
- **`README.md`**
  - Added a new option, `--shortcut-url`, in the description of the `description` command.
- **`cmd/description/main.go`**
  - Added functionality to extract and display Shortcut story IDs from GitHub pull request title or branch name.
  - Added functionality to generate a link to the corresponding Shortcut story if a Shortcut base URL is provided.
  - Updated the 'opts' struct to include a new field for the Shortcut base URL.
  - Rearranged import statements and added a new import for the 'shortcut' package.
- **`shortcut/shortcut.go`**
  - Introduced a new function, 'ExtractShortcutStoryId', to extract a Shortcut story ID from a string using a regular expression.
  - Introduced another new function, 'GenerateShortcutStoryUrl', to generate a Shortcut story URL using a base URL and a ticket ID.
- **`shortcut/shortcut_test.go`**
  - Introduced two new test functions, 'TestExtractShortcutStoryID' and 'TestGenerateShortcutStoryURL', to test the new functions in the 'shortcut' package.

## Impact
The changes will enhance the tool's functionality by allowing users to generate Shortcut links in the description, extract and display Shortcut story IDs, and generate a Shortcut story URL using a base URL and a ticket ID. This will improve the tool's usability and efficiency.