### PR TITLE
Use placeholder for description

### DIFF
--- a/description/description.go
+++ b/description/description.go
@@ -10,6 +10,12 @@ import (
 	oAIClient "github.com/ravilushqa/gpt-pullrequest-updater/openai"
 )
 
+const Placeholder = "gpt-updater:description"
+const PlaceholderHidden = `<!--
+gpt-updater:description
+-->
+`
+
 func GenerateCompletion(ctx context.Context, client *oAIClient.Client, diff *github.CommitsComparison, pr *github.PullRequest) (string, error) {
 	sumDiffs := calculateSumDiffs(diff)
 


### PR DESCRIPTION
My own static description


## 🤖 gpt-updater description
<!--
gpt-updater:description
-->
### Shortcut story: [25996](https://app.shortcut.com/qonversion/story/25996)

This patch introduces a new struct `prDataType` to hold the completion, Jira info, and Shortcut info related to a pull request. It also introduces a new function `buildUpdatedDescription` to construct the updated pull request description using the `prDataType`. The function checks if each field in `prDataType` is not empty before appending it to the description. If the existing body contains the placeholder, it replaces the placeholder with the new description. The patch also adds a constant for the placeholder and its hidden version.